### PR TITLE
Add signature pad and OneDrive form instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Forklift Inspection App
+
+This project provides a tablet-friendly web application to fill out forklift inspection forms and save the result to OneDrive.
+
+## Features
+- React + TypeScript frontend using Material UI
+- Digital signature capture
+- Saves form data as JSON in your OneDrive using Microsoft Graph
+
+## Setup
+1. Run `setup.sh` to install dependencies.
+2. Replace `YOUR_CLIENT_ID` in `inspection-form/src/App.tsx` and `inspection-form/src/services/OneDriveService.ts` with your Azure app Client ID.
+3. Start the app:
+   ```bash
+   cd inspection-form
+   npm start
+   ```
+
+The application will open in your browser at `http://localhost:3000`.
+
+## Usage
+Fill in the fields, sign with your finger or a stylus, and click **Enregistrer**. A JSON file is uploaded to your OneDrive under the root folder.

--- a/inspection-form/README.md
+++ b/inspection-form/README.md
@@ -44,3 +44,8 @@ You don’t have to ever use `eject`. The curated feature set is suitable for sm
 You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
 
 To learn React, check out the [React documentation](https://reactjs.org/).
+
+## Forklift Inspection Form
+
+This application renders a digital version of the forklift inspection checklist. It includes fields for the operator information and a signature area. When the form is submitted, the data is uploaded to OneDrive as a JSON file.
+

--- a/inspection-form/src/components/InspectionForm.tsx
+++ b/inspection-form/src/components/InspectionForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import {
     Box,
@@ -12,15 +12,29 @@ import {
     Paper,
     Container,
 } from '@mui/material';
+import SignaturePad, { SignaturePadRef } from './SignaturePad';
 import { InspectionForm } from '../types/InspectionTypes';
 import { INSPECTION_SECTIONS } from '../constants/inspectionData';
 import { saveToOneDrive } from '../services/OneDriveService';
 
 const InspectionFormComponent: React.FC = () => {
-    const { control, handleSubmit } = useForm<InspectionForm>();
+    const signatureRef = useRef<SignaturePadRef>(null);
+    const { control, handleSubmit } = useForm<InspectionForm>({
+        defaultValues: {
+            date: '',
+            operator: '',
+            signature: '',
+            truckNumber: '',
+            registration: '',
+            department: '',
+        }
+    });
 
     const onSubmit = async (data: InspectionForm) => {
         try {
+            if (signatureRef.current) {
+                data.signature = signatureRef.current.getImage();
+            }
             await saveToOneDrive(data);
             console.log('Form data:', data);
         } catch (error) {
@@ -109,6 +123,26 @@ const InspectionFormComponent: React.FC = () => {
                             )}
                         />
                     </Grid>
+                    <Grid item xs={12} md={4} component="div">
+                        <Controller
+                            name="registration"
+                            control={control}
+                            defaultValue=""
+                            render={({ field }) => (
+                                <TextField {...field} label="Immatriculation" fullWidth />
+                            )}
+                        />
+                    </Grid>
+                    <Grid item xs={12} md={4} component="div">
+                        <Controller
+                            name="department"
+                            control={control}
+                            defaultValue=""
+                            render={({ field }) => (
+                                <TextField {...field} label="Département" fullWidth />
+                            )}
+                        />
+                    </Grid>
                 </Grid>
 
                 <Typography variant="h5" gutterBottom sx={{ mt: 4 }}>
@@ -124,6 +158,14 @@ const InspectionFormComponent: React.FC = () => {
                 {Object.entries(INSPECTION_SECTIONS.operationalInspection).map(([key, section]) => (
                     renderInspectionSection(section, `operationalInspection.${key}`)
                 ))}
+
+                <Typography variant="h5" gutterBottom sx={{ mt: 4 }}>
+                    Signature de l'opérateur
+                </Typography>
+                <Box sx={{ mb: 2 }}>
+                    <SignaturePad ref={signatureRef} />
+                </Box>
+                <Button variant="text" onClick={() => signatureRef.current?.clear()}>Effacer la signature</Button>
 
                 <Box sx={{ mt: 4, mb: 4 }}>
                     <Button variant="contained" color="primary" type="submit" size="large">

--- a/inspection-form/src/components/SignaturePad.tsx
+++ b/inspection-form/src/components/SignaturePad.tsx
@@ -1,0 +1,60 @@
+import React, { useRef, useImperativeHandle, forwardRef, useEffect } from 'react';
+
+export interface SignaturePadRef {
+  clear: () => void;
+  getImage: () => string;
+}
+
+const SignaturePad = forwardRef<SignaturePadRef>((_, ref) => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const drawing = useRef(false);
+
+  useImperativeHandle(ref, () => ({
+    clear() {
+      const ctx = canvasRef.current?.getContext('2d');
+      if (ctx && canvasRef.current) {
+        ctx.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
+      }
+    },
+    getImage() {
+      return canvasRef.current?.toDataURL('image/png') || '';
+    },
+  }));
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const start = (e: PointerEvent) => {
+      drawing.current = true;
+      ctx.beginPath();
+      ctx.moveTo(e.offsetX, e.offsetY);
+    };
+
+    const move = (e: PointerEvent) => {
+      if (!drawing.current) return;
+      ctx.lineTo(e.offsetX, e.offsetY);
+      ctx.stroke();
+    };
+
+    const end = () => {
+      drawing.current = false;
+    };
+
+    canvas.addEventListener('pointerdown', start);
+    canvas.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', end);
+
+    return () => {
+      canvas.removeEventListener('pointerdown', start);
+      canvas.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', end);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} width={600} height={150} style={{ width: '100%', height: '150px', border: '1px solid #ccc' }} />;
+});
+
+export default SignaturePad;


### PR DESCRIPTION
## Summary
- create a project README with setup instructions
- document inspection form improvements
- add a canvas-based signature pad component
- integrate signature pad into the inspection form

## Testing
- `node node_modules/react-scripts/bin/react-scripts.js test --watchAll=false` *(fails: Cannot find module '@testing-library/jest-dom')*