### PR TITLE
Save forms inside OneDrive subfolder

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,4 @@ Alternatively, you can expose the server on the internet using `ngrok`:
 The ngrok URL will work from anywhere but changes each time with the free plan. Using the local network avoids this issue and costs nothing. You may assign a static IP to your computer for a truly constant address.
 
 ## Usage
-Fill in the fields, sign with your finger or a stylus, and click **Enregistrer**. A JSON file is uploaded to your OneDrive under the root folder.
+Fill in the fields, sign with your finger or a stylus, and click **Enregistrer**. A JSON file is uploaded to the `Inspections` folder in your OneDrive.

--- a/inspection-form/src/components/InspectionForm.tsx
+++ b/inspection-form/src/components/InspectionForm.tsx
@@ -83,7 +83,7 @@ const RadioButton = styled(Box, {
 
 const InspectionFormComponent: React.FC = () => {
     const signatureRef = useRef<SignaturePadRef>(null);
-    const { control, handleSubmit } = useForm<InspectionForm>({
+    const { control, handleSubmit, reset } = useForm<InspectionForm>({
         defaultValues: {
             date: '',
             operator: '',
@@ -97,12 +97,26 @@ const InspectionFormComponent: React.FC = () => {
     const onSubmit = async (data: InspectionForm) => {
         try {
             if (signatureRef.current) {
+                if (signatureRef.current.isEmpty()) {
+                    alert('Veuillez ajouter votre signature.');
+                    return;
+                }
                 data.signature = signatureRef.current.getImage();
             }
+
+            if (!data.date) {
+                alert('Veuillez saisir la date.');
+                return;
+            }
+
             await saveToOneDrive(data);
+            alert('Sauvegarde réussie');
+            reset();
+            signatureRef.current?.clear();
             console.log('Form data:', data);
         } catch (error) {
             console.error('Error saving form:', error);
+            alert('Erreur lors de la sauvegarde');
         }
     };
 

--- a/inspection-form/src/components/SignaturePad.tsx
+++ b/inspection-form/src/components/SignaturePad.tsx
@@ -3,11 +3,13 @@ import React, { useRef, useImperativeHandle, forwardRef, useEffect } from 'react
 export interface SignaturePadRef {
   clear: () => void;
   getImage: () => string;
+  isEmpty: () => boolean;
 }
 
 const SignaturePad = forwardRef<SignaturePadRef>((_, ref) => {
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const drawing = useRef(false);
+  const hasSignature = useRef(false);
   const contextRef = useRef<CanvasRenderingContext2D | null>(null);
 
   useImperativeHandle(ref, () => ({
@@ -17,9 +19,13 @@ const SignaturePad = forwardRef<SignaturePadRef>((_, ref) => {
       if (ctx && canvas) {
         ctx.clearRect(0, 0, canvas.width, canvas.height);
       }
+      hasSignature.current = false;
     },
     getImage() {
       return canvasRef.current?.toDataURL('image/png') || '';
+    },
+    isEmpty() {
+      return !hasSignature.current;
     },
   }));
 
@@ -42,6 +48,7 @@ const SignaturePad = forwardRef<SignaturePadRef>((_, ref) => {
 
     const startDrawing = (x: number, y: number) => {
       drawing.current = true;
+      hasSignature.current = true;
       ctx.beginPath();
       ctx.moveTo(x, y);
     };


### PR DESCRIPTION
## Summary
- upload JSON files inside an `Inspections` folder in OneDrive
- create the folder automatically if needed
- reset the form and show alerts when saving
- require a signature and date before saving
- track if the signature canvas is empty
- update docs

## Testing
- `npm test --silent` *(fails: react-scripts Permission denied)*