### PR TITLE
Fix saving forms from mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,16 @@ All `npm` commands must be run from the `inspection-form/` directory. The root
    ID.
 3. (Optional) [Download ngrok](https://ngrok.com/download) and place the binary
    in the `ngrok/` folder so that `ngrok/ngrok` exists.
-4. Start the app:
+4. Build the frontend and start the local server:
    ```bash
    cd inspection-form
-   npm start
+   npm run build
+   node server.js
    ```
+
+   The application will be available on `http://localhost:3000`. You can open
+   the same URL from another device on your network by replacing `localhost` with
+   your computer's IP address.
 
 ### Running tests
 After installing dependencies with `setup.sh` or `setup.ps1`, you can execute the unit tests:
@@ -32,7 +37,8 @@ npm test
 
 This runs `react-scripts` in non-interactive mode and reports the results in the console.
 
-The application will open in your browser at `http://localhost:3001` by default.
+When using `start-local.sh` for development the app opens at
+`http://localhost:3001`.
 
 ### Access from mobile devices
 

--- a/inspection-form/server.js
+++ b/inspection-form/server.js
@@ -17,6 +17,8 @@ app.post('/api/save', async (req, res) => {
         const fileName = `inspection_${new Date().toISOString().replace(/[:.]/g, '-')}.json`;
         const fullPath = path.join(SAVE_PATH, fileName);
 
+        // Ensure the destination folder exists before writing
+        await fs.mkdir(SAVE_PATH, { recursive: true });
         await fs.writeFile(fullPath, JSON.stringify(formData, null, 2), 'utf8');
         res.json({ success: true, message: 'Fichier sauvegardé avec succès' });
     } catch (error) {

--- a/inspection-form/src/services/OneDriveService.ts
+++ b/inspection-form/src/services/OneDriveService.ts
@@ -1,11 +1,12 @@
-import { writeFile } from 'fs/promises';
-import { join } from 'path';
-
-const SAVE_PATH = 'C:\\Users\\vcasaubon.NOOVELIA\\Noovelia\\!SST - General\\Inspection chariot élévateur\\Fiche inspection app';
+// Utility to save the inspection data on the local server
+// The server exposes an /api/save endpoint that writes the JSON file to disk.
 
 export const saveLocally = async (formData: any) => {
     try {
-        const response = await fetch('http://10.136.136.143:3000/api/save', {
+        // Use a relative URL so the request targets the same host that served
+        // the application. This works whether the app is accessed from the
+        // local machine or another device on the network.
+        const response = await fetch('/api/save', {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',

--- a/start-local.sh
+++ b/start-local.sh
@@ -3,7 +3,7 @@
 
 # Load PORT from .env if available
 PORT=${PORT:-$(grep -m1 '^PORT=' inspection-form/.env 2>/dev/null | cut -d '=' -f2)}
-[ -z "$PORT" ] && PORT=3000
+[ -z "$PORT" ] && PORT=3001
 
 # Determine local IP address (first non-loopback IPv4)
 IP=$(hostname -I | awk '{print $1}')


### PR DESCRIPTION
## Summary
- use relative API path so requests work from any device
- ensure save directory exists before writing
- default `start-local.sh` to port 3001
- update README with instructions for running the server

## Testing
- `npm test` *(fails: Cannot find module '@testing-library/jest-dom')*