### PR TITLE
Add PDF output for inspections

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This project provides a tablet-friendly web application to fill out forklift ins
 ## Features
 - React + TypeScript frontend using Material UI
 - Digital signature capture
-- Saves form data as JSON in your OneDrive using Microsoft Graph
+- Saves form data as JSON and automatically generates a PDF summary
+  next to the JSON file
 
 ## Setup
 All `npm` commands must be run from the `inspection-form/` directory. The root
@@ -64,4 +65,6 @@ Alternatively, you can expose the server on the internet using `ngrok`:
 The ngrok URL will work from anywhere but changes each time with the free plan. Using the local network avoids this issue and costs nothing. You may assign a static IP to your computer for a truly constant address.
 
 ## Usage
-Fill in the fields, sign with your finger or a stylus, and click **Enregistrer**. A JSON file is uploaded to your specified save directory.
+Fill in the fields, sign with your finger or a stylus, and click **Enregistrer**.
+The server stores the inspection as a JSON file and also creates a human
+readable PDF file in the same folder.

--- a/inspection-form/README.md
+++ b/inspection-form/README.md
@@ -47,5 +47,5 @@ To learn React, check out the [React documentation](https://reactjs.org/).
 
 ## Forklift Inspection Form
 
-This application renders a digital version of the forklift inspection checklist. It includes fields for the operator information and a signature area. When the form is submitted, the data is uploaded to OneDrive as a JSON file.
+This application renders a digital version of the forklift inspection checklist. It includes fields for the operator information and a signature area. When the form is submitted, the data is uploaded to OneDrive as a JSON file and a PDF summary is created on the server.
 

--- a/inspection-form/pdfGenerator.js
+++ b/inspection-form/pdfGenerator.js
@@ -1,0 +1,32 @@
+function generatePDF(data) {
+  const lines = Object.entries(data).map(([k, v]) => `${k}: ${v}`);
+  let content = ['BT', '/F1 12 Tf'];
+  let y = 750;
+  for (const line of lines) {
+    const esc = String(line).replace(/([()\\])/g, '\\$1');
+    content.push(`50 ${y} Td (${esc}) Tj`);
+    y -= 14;
+  }
+  content.push('ET');
+  const contentStream = content.join('\n');
+
+  const header = '%PDF-1.7\n';
+  const objs = []; const offs = []; let offset = header.length;
+  const add = txt => { objs.push(txt); offs.push(offset); offset += Buffer.byteLength(txt); };
+
+  add('1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n');
+  add('2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n');
+  add('3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n');
+  add(`4 0 obj\n<< /Length ${Buffer.byteLength(contentStream)} >>\nstream\n${contentStream}\nendstream\nendobj\n`);
+  add('5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n');
+
+  let xref = 'xref\n0 6\n0000000000 65535 f \n';
+  for (const o of offs) {
+    xref += String(o).padStart(10, '0') + ' 00000 n \n';
+  }
+  const trailer = `trailer\n<< /Root 1 0 R /Size 6 >>\nstartxref\n${offset}\n%%EOF`;
+
+  return header + objs.join('') + xref + trailer;
+}
+
+module.exports = { generatePDF };

--- a/inspection-form/server.js
+++ b/inspection-form/server.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 const fs = require('fs').promises;
 const path = require('path');
 const os = require('os');
+const { generatePDF } = require('./pdfGenerator');
 const networkInterfaces = os.networkInterfaces();
 
 const app = express();
@@ -36,6 +37,17 @@ app.post('/api/save', async (req, res) => {
         // Ensure the destination folder exists before writing
         await fs.mkdir(SAVE_PATH, { recursive: true });
         await fs.writeFile(fullPath, JSON.stringify(formData, null, 2), 'utf8');
+
+        // Write a PDF summary alongside the JSON file
+        try {
+            const pdfPath = fullPath.replace(/\.json$/, '.pdf');
+            const pdfContent = generatePDF(formData);
+            await fs.writeFile(pdfPath, pdfContent, 'binary');
+            console.log('PDF créé avec succès');
+        } catch (pdfErr) {
+            console.error('Erreur lors de la création du PDF:', pdfErr);
+        }
+
         console.log('Fichier sauvegardé avec succès');
         res.json({ success: true, message: 'Fichier sauvegardé avec succès' });
     } catch (error) {


### PR DESCRIPTION
## Summary
- generate simple PDF files on the server using new `pdfGenerator`
- save the PDF alongside the JSON output
- document the new behaviour in READMEs

## Testing
- `npm test --silent` *(fails: react-scripts permission denied)*